### PR TITLE
Add extended packet logging with MAC and TCP details

### DIFF
--- a/csv_logger.py
+++ b/csv_logger.py
@@ -10,23 +10,56 @@ def set_csv_file(file_path):
     os.makedirs(os.path.dirname(csv_file), exist_ok=True)
     with open(csv_file, mode="w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["timestamp", "src_ip", "src_port", "dst_ip", "dst_port", "function_code", "payload"])
+        writer.writerow([
+            "timestamp",
+            "src_ip",
+            "src_port",
+            "dst_ip",
+            "dst_port",
+            "function_code",
+            "payload",
+            "eth_src",
+            "eth_dst",
+            "tcp_flags",
+            "packet_length",
+            "transaction_id",
+        ])
 
 def log_to_csv(packet, data):
     if not csv_file:
         return  # CSV ainda não definido
 
-    src_ip = packet["IP"]["src"]
-    dst_ip = packet["IP"]["dst"]
-    src_port = packet["TCP"]["sport"]
-    dst_port = packet["TCP"]["dport"]
+    src_ip = packet.get("IP", {}).get("src", "")
+    dst_ip = packet.get("IP", {}).get("dst", "")
+    src_port = packet.get("TCP", {}).get("sport", "")
+    dst_port = packet.get("TCP", {}).get("dport", "")
+    eth_src = packet.get("Ethernet", {}).get("src", "")
+    eth_dst = packet.get("Ethernet", {}).get("dst", "")
+    tcp_flags = packet.get("TCP", {}).get("flags", "")
+    packet_length = packet.get("length", "")
+    timestamp = packet.get("timestamp")
+    if timestamp is not None:
+        ts_str = datetime.fromtimestamp(float(timestamp)).strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        ts_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
     function_code = data.get("function_code", "?")
     payload = data.get("payload", "")
+    transaction_id = data.get("transaction_id", "?")
 
     with open(csv_file, mode="a", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
-            datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            src_ip, src_port, dst_ip, dst_port,
-            function_code, payload
+            ts_str,
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            function_code,
+            payload,
+            eth_src,
+            eth_dst,
+            tcp_flags,
+            packet_length,
+            transaction_id,
         ])

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,25 @@
+from typing import Optional, Dict
+
+
+def parse_modbus_packet(tcp_payload: bytes) -> Optional[Dict[str, int | str]]:
+    """Parse raw Modbus/TCP payload and return a dictionary with key fields."""
+    if not tcp_payload or len(tcp_payload) < 8:
+        return None
+    try:
+        transaction_id = int.from_bytes(tcp_payload[0:2], "big")
+        protocol_id = int.from_bytes(tcp_payload[2:4], "big")
+        length = int.from_bytes(tcp_payload[4:6], "big")
+        unit_id = tcp_payload[6]
+        function_code = tcp_payload[7]
+        payload = tcp_payload[7:].hex()
+        return {
+            "transaction_id": transaction_id,
+            "protocol_id": protocol_id,
+            "length": length,
+            "unit_id": unit_id,
+            "function_code": function_code,
+            "payload": payload,
+        }
+    except Exception:
+        return None
+

--- a/tshark_parser.py
+++ b/tshark_parser.py
@@ -1,7 +1,9 @@
 import threading
 import subprocess
 import json
+import yaml
 from queue import Queue
+from parser import parse_modbus_packet
 
 tshark_packet_queue = Queue()
 
@@ -34,17 +36,47 @@ def tshark_parser_thread():
                     packets = json.loads(buffer)
                     for pkt in packets:
                         layers = pkt.get("_source", {}).get("layers", {})
+                        timestamp = layers.get("frame.time_epoch", [None])[0]
+                        frame_len = int(layers.get("frame.len", [0])[0])
+                        eth_src = layers.get("eth.src", [None])[0]
+                        eth_dst = layers.get("eth.dst", [None])[0]
                         ip_src = layers.get("ip.src", [None])[0]
                         ip_dst = layers.get("ip.dst", [None])[0]
                         tcp_sport = int(layers.get("tcp.srcport", [0])[0])
                         tcp_dport = int(layers.get("tcp.dstport", [0])[0])
+                        tcp_flags = layers.get("tcp.flags", [""])[0]
                         payload = layers.get("data.data", [""])[0]
 
+                        raw_bytes = bytes.fromhex(payload) if payload else b""
+                        modbus_info = parse_modbus_packet(raw_bytes)
+
                         packet = {
+                            "timestamp": float(timestamp) if timestamp else None,
+                            "length": frame_len,
+                            "Ethernet": {"src": eth_src, "dst": eth_dst},
                             "IP": {"src": ip_src, "dst": ip_dst},
-                            "TCP": {"sport": tcp_sport, "dport": tcp_dport},
-                            "TCP_raw": bytes.fromhex(payload) if payload else b""
+                            "TCP": {
+                                "sport": tcp_sport,
+                                "dport": tcp_dport,
+                                "flags": tcp_flags
+                            },
+                            "TCP_raw": raw_bytes,
+                            "src_ip": ip_src,
+                            "dst_ip": ip_dst,
+                            "src_port": tcp_sport,
+                            "dst_port": tcp_dport
                         }
+
+                        if modbus_info:
+                            packet.update(modbus_info)
+                        else:
+                            packet.update({
+                                "transaction_id": None,
+                                "protocol_id": None,
+                                "unit_id": None,
+                                "function_code": "?",
+                                "payload": payload,
+                            })
 
                         tshark_packet_queue.put(packet)
                 except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- enhance tshark parser to include MAC addresses, TCP flags, length and timestamp
- implement `parse_modbus_packet` helper
- extend CSV logging with new columns including MAC info, flags, packet length and transaction id

## Testing
- `python -m py_compile csv_logger.py parser.py tshark_parser.py daemon.py`

------
https://chatgpt.com/codex/tasks/task_e_684212f3d50c8324950629fa3ed3769b