### PR TITLE
Add ARP spoofing detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,8 @@ MODBUS_SERVER:
   - 172.27.224.250
 
 rules_file: rules/modsentinel.rules
+
+# Lista de pares IP-MAC permitidos para deteção de ARP spoofing
+allowed_macs:
+  "172.27.224.10": "00:11:22:33:44:55"
+  "172.27.224.250": "66:77:88:99:AA:BB"


### PR DESCRIPTION
## Summary
- capture ARP packets in tshark parser
- map IP/MAC addresses from `config.yaml`
- warn when a MAC address differs from the configured value
- add example allowed MAC addresses to `config.yaml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684222569b38832490982408aea6f3bb