### PR TITLE
Log malicious status in CSV

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,8 @@ MODBUS_SERVER:
   - 172.27.224.250
 
 rules_file: rules/modsentinel.rules
+
+# Lista de pares IP-MAC permitidos para deteção de ARP spoofing
+allowed_macs:
+  "172.27.224.10": "00:11:22:33:44:55"
+  "172.27.224.250": "66:77:88:99:AA:BB"

--- a/csv_logger.py
+++ b/csv_logger.py
@@ -10,9 +10,18 @@ def set_csv_file(file_path):
     os.makedirs(os.path.dirname(csv_file), exist_ok=True)
     with open(csv_file, mode="w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["timestamp", "src_ip", "src_port", "dst_ip", "dst_port", "function_code", "payload"])
+        writer.writerow([
+            "timestamp",
+            "src_ip",
+            "src_port",
+            "dst_ip",
+            "dst_port",
+            "function_code",
+            "payload",
+            "malicious",
+        ])
 
-def log_to_csv(packet, data):
+def log_to_csv(packet, data, status):
     if not csv_file:
         return  # CSV ainda não definido
 
@@ -22,11 +31,17 @@ def log_to_csv(packet, data):
     dst_port = packet["TCP"]["dport"]
     function_code = data.get("function_code", "?")
     payload = data.get("payload", "")
+    malicious = 1 if status == "Malicious" else 0
 
     with open(csv_file, mode="a", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
             datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            src_ip, src_port, dst_ip, dst_port,
-            function_code, payload
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            function_code,
+            payload,
+            malicious,
         ])

--- a/daemon.py
+++ b/daemon.py
@@ -79,7 +79,7 @@ def daemon_loop():
                             f"{parsed_packet['IP']['dst']}:{parsed_packet['TCP']['dport']} | FC: {parsed_packet['function_code']}"
                         )
                     log_event(parsed_packet, parsed_packet, status, rule)
-                    log_to_csv(parsed_packet, parsed_packet)
+                    log_to_csv(parsed_packet, parsed_packet, status)
 
             except Exception as e:
                 logger.exception(f"Erro ao processar pacote: {e}")
@@ -94,7 +94,7 @@ def daemon_loop():
                 if verbose_mode:
                     logger.info(f"[VERBOSE][TEST MODE] Pacote gerado: FC: {modbus_data['function_code']}")
                 log_event(fake_packet, modbus_data, status, rule)
-                log_to_csv(fake_packet, modbus_data)
+                log_to_csv(fake_packet, modbus_data, status)
                 last_test_log = time.time()
 
             time.sleep(0.1)


### PR DESCRIPTION
## Summary
- add `malicious` column to traffic CSV
- store 1 for malicious detections, 0 otherwise
- update daemon to pass status to the logger

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684222569b38832490982408aea6f3bb